### PR TITLE
Update readme and magic_logger

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/rcourivaud/logstash_logger/issues.
+Report bugs at https://github.com/rcourivaud/magiclogger/issues.
 
 If you are reporting a bug, please include:
 
@@ -38,14 +38,14 @@ and "help wanted" is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Logstash Logger could always use more documentation, whether as part of the
+MagicLogger could always use more documentation, whether as part of the
 official Logstash Logger docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/rcourivaud/logstash_logger/issues.
+The best way to send feedback is to file an issue at https://github.com/rcourivaud/magiclogger/issues.
 
 If you are proposing a feature:
 
@@ -57,17 +57,17 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `logstash_logger` for local development.
+Ready to contribute? Here's how to set up `magic_logger` for local development.
 
-1. Fork the `logstash_logger` repo on GitHub.
+1. Fork the `magic_logger` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/logstash_logger.git
+    $ git clone git@github.com:your_name_here/magiclogger.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv logstash_logger
-    $ cd logstash_logger/
+    $ mkvirtualenv magic_logger
+    $ cd MagicLogger/
     $ python setup.py develop
 
 4. Create a branch for local development::
@@ -78,7 +78,7 @@ Ready to contribute? Here's how to set up `logstash_logger` for local developmen
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 logstash_logger tests
+    $ flake8 magic_logger tests
     $ python setup.py test or py.test
     $ tox
 
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
-   https://travis-ci.org/rcourivaud/logstash_logger/pull_requests
+   https://travis-ci.org/rcourivaud/magiclogger/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips
@@ -111,4 +111,4 @@ Tips
 To run a subset of tests::
 
 
-    $ python -m unittest tests.test_logstash_logger
+    $ python -m unittest tests.test_magic_logger

--- a/README.rst
+++ b/README.rst
@@ -53,58 +53,50 @@ How to use
 
 .. code-block:: python
 
-    logger = MagicLogger('Name')
+    logger = MagicLogger('Name', host='localhost')
 
 3. Decorate a function in order to log it into Logstash and into the console
 
 .. code-block:: python
 
     @logger.decorate('This is a message.')
-    def a():
+    def a(*args, **kwargs):
         return 'This is a return'
+    
+    a('arg_1', 'arg_2', kwarg_1='hello', kwarg_2='world') 
 
 Terminal output:
 
 .. code-block:: bash
 
-    2018-05-25 17:04:26,314 - Name - INFO - Connection to logstash successful.
-    2018-05-25 17:04:26,321 - Name - DEBUG - This is a message
+    2018-05-25 23:09:35,514 - Name - INFO - Connection to logstash successful.
+    2018-05-25 23:09:35,518 - Name - DEBUG - This is a message.
 
 Logstash output:
 
 .. code-block:: bash
 
     logstash_1       | {
-    logstash_1       |      "@timestamp" => 2018-05-25T15:04:26.314Z,
-    logstash_1       |         "message" => "Connection to logstash successful.",
-    logstash_1       |            "type" => "logstash",
-    logstash_1       |      "stack_info" => nil,
-    logstash_1       |     "logger_name" => "Name",
-    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
-    logstash_1       |            "port" => 33506,
-    logstash_1       |        "@version" => "1",
-    logstash_1       |            "tags" => [],
-    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
-    logstash_1       |           "level" => "INFO"
-    logstash_1       | }
-    logstash_1       | {
-    logstash_1       |      "execution_time" => 9.0e-06,
-    logstash_1       |      "function_class" => nil,
-    logstash_1       |        "function_res" => "This is a return",
-    logstash_1       |          "@timestamp" => 2018-05-25T15:04:26.321Z,
-    logstash_1       |             "message" => "This is a message",
-    logstash_1       |                "type" => "logstash",
     logstash_1       |          "stack_info" => nil,
-    logstash_1       |         "logger_name" => "Name",
-    logstash_1       |       "function_name" => "a",
-    logstash_1       |                "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
-    logstash_1       |                "port" => 33506,
     logstash_1       |            "@version" => "1",
-    logstash_1       |                "tags" => [],
+    logstash_1       |                "type" => "logstash",
+    logstash_1       |             "message" => "This is a message.",
+    logstash_1       |     "function_kwargs" => {
+    logstash_1       |         "kwarg_2" => "world",
+    logstash_1       |         "kwarg_1" => "hello"
+    logstash_1       |     },
+    logstash_1       |                "host" => "Nicolass-MacBook-Pro.local",
+    logstash_1       |       "function_name" => "a",
+    logstash_1       |                "path" => "/Users/nico/corners/MagicLogger/magic_logger/magic_logger.py",
     logstash_1       |               "class" => nil,
-    logstash_1       |                "host" => "MBP-C02WC1F4HV2Q.local",
-    logstash_1       |     "function_kwargs" => {},
-    logstash_1       |               "level" => "DEBUG"
+    logstash_1       |                "port" => 51772,
+    logstash_1       |               "level" => "DEBUG",
+    logstash_1       |                "tags" => [],
+    logstash_1       |        "function_res" => "This is a return",
+    logstash_1       |          "@timestamp" => 2018-05-25T21:09:35.518Z,
+    logstash_1       |      "execution_time" => 5.0e-06,
+    logstash_1       |         "logger_name" => "Name",
+    logstash_1       |      "function_class" => nil
     logstash_1       | }
 
 5. Add an extra to the decorator within the decorated function with the `update_extra` method
@@ -115,6 +107,8 @@ Logstash output:
     def a():
         logger.update_extra(post_extra='This is a new extra')
         return 'This is a return'
+
+    a()
 
 6. Write a regular log
 

--- a/README.rst
+++ b/README.rst
@@ -109,17 +109,19 @@ Logstash output:
 
 4. Write a regular log
 
-    .. code-block:: bash
+    .. code-block:: python
 
     test_list = [1, 2, 3]
     test_string = "This is a string"
     logger.info('This is a message', extra = {"a_list": test_list, "a_string": test_string})
 
-Logstash output:
+Terminal output:
 
     .. code-block:: bash
 
     2018-05-25 17:08:15,654 - Name - INFO - This is a message
+
+Logstash output:
 
     .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Logstash output:
     logstash_1       |      "function_class" => nil
     logstash_1       | }
 
-5. Add an extra to the decorator within the decorated function with the `update_extra` method
+4. Add an extra to the decorator within the decorated function with the `update_extra` method
 
 .. code-block:: python
 
@@ -110,7 +110,7 @@ Logstash output:
 
     a()
 
-6. Write a regular log
+5. Write a regular log
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ How to use
 
     logger = MagicLogger('Name')
 
-3. Decorate a function in order to log it into Logstash and into the console.
+3. Decorate a function in order to log it into Logstash and into the console
 
 .. code-block:: python
 
@@ -74,32 +74,6 @@ Logstash output:
 
 .. code-block:: bash
 
-    logstash_1       | {
-    logstash_1       |      "@timestamp" => 2018-05-25T09:39:21.669Z,
-    logstash_1       |         "message" => "This is a message",
-    logstash_1       |            "type" => "logstash",
-    logstash_1       |      "stack_info" => nil,
-    logstash_1       |     "logger_name" => "Name",
-    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
-    logstash_1       |            "port" => 55684,
-    logstash_1       |        "@version" => "1",
-    logstash_1       |            "tags" => [],
-    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
-    logstash_1       |           "level" => "DEBUG"
-    logstash_1       | }
-    logstash_1       | {
-    logstash_1       |      "@timestamp" => 2018-05-25T09:39:21.663Z,
-    logstash_1       |         "message" => "Connection to logstash successful.",
-    logstash_1       |            "type" => "logstash",
-    logstash_1       |      "stack_info" => nil,
-    logstash_1       |     "logger_name" => "Name",
-    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
-    logstash_1       |            "port" => 55684,
-    logstash_1       |        "@version" => "1",
-    logstash_1       |            "tags" => [],
-    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
-    logstash_1       |           "level" => "INFO"
-    logstash_1       | }
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 Enable your Logstash pipeline to listen to incoming JSON streams on port 5000
 
-.. code-block:: json
+.. code-block:: conf
 
     input {
         tcp {

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ How to use
 
     from magic_logger import MagicLogger
 
-2. Instantiate MagicLogger with a name. Logstash host is changed with kwarg `host`.
-   If you have a specific Logstash host, feel free to edit the `magic_logger.py` default host.
+2. Instantiate MagicLogger with a name. Logstash host is changed with `host` parameter.
+   If you have a specific and recurrent Logstash host, feel free to edit the `magic_logger.py` default host.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Logstash output:
 
 4. Write a regular log
 
-    .. code-block:: python
+.. code-block:: python
 
     test_list = [1, 2, 3]
     test_string = "This is a string"
@@ -117,13 +117,13 @@ Logstash output:
 
 Terminal output:
 
-    .. code-block:: bash
+.. code-block:: bash
 
     2018-05-25 17:08:15,654 - Name - INFO - This is a message
 
 Logstash output:
 
-    .. code-block:: bash
+.. code-block:: bash
 
     logstash_1       | {
     logstash_1       |      "@timestamp" => 2018-05-25T15:08:15.654Z,

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,7 @@ Logstash Logger
      :alt: Updates
 
 
-Logstash Logger handler connect to ELK stack
-
+Log handler to log better and send logs to Logstash
 
 * Free software: MIT license
 * Documentation: https://logstash-logger.readthedocs.io.
@@ -28,7 +27,9 @@ Logstash Logger handler connect to ELK stack
 Features
 --------
 
-`pip install logstash_logger`
+.. code-block:: bash
+
+    pip install magic_logger
 
 Credits
 ---------
@@ -37,4 +38,36 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
+
+How to use
+----------
+
+1. Import module
+
+.. code-block:: python
+
+    from magic_logger import MagicLogger
+
+2. Instantiate MagicLogger with a name. Logstash host is changed with kwarg `host`.
+
+.. code-block:: python
+
+    logger = MagicLogger('Name')
+
+3. Decorate a function in order to log it into Logstash and into the console.
+
+.. code-block:: python
+
+    @logger.decorate('This is a message.')
+    def a():
+        return 'This is a return'
+
+Output
+
+.. code-block:: bash
+
+
+
+
+
 

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,16 @@ Logstash output:
     logstash_1       |               "level" => "DEBUG"
     logstash_1       | }
 
-4. Write a regular log
+5. Add an extra to the decorator within the decorated function with the `update_extra` method
+
+.. code-block:: python
+
+    @logger.decorate('This is a message')
+    def a():
+        logger.update_extra(post_extra='This is a new extra')
+        return 'This is a return'
+
+6. Write a regular log
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -67,16 +67,79 @@ Terminal output:
 
 .. code-block:: bash
 
-    2018-05-25 11:39:21,663 - Name - INFO - Connection to logstash successful.
-    2018-05-25 11:39:21,669 - Name - DEBUG - This is a message
+    2018-05-25 17:04:26,314 - Name - INFO - Connection to logstash successful.
+    2018-05-25 17:04:26,321 - Name - DEBUG - This is a message
 
 Logstash output:
 
 .. code-block:: bash
 
+    logstash_1       | {
+    logstash_1       |      "@timestamp" => 2018-05-25T15:04:26.314Z,
+    logstash_1       |         "message" => "Connection to logstash successful.",
+    logstash_1       |            "type" => "logstash",
+    logstash_1       |      "stack_info" => nil,
+    logstash_1       |     "logger_name" => "Name",
+    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
+    logstash_1       |            "port" => 33506,
+    logstash_1       |        "@version" => "1",
+    logstash_1       |            "tags" => [],
+    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
+    logstash_1       |           "level" => "INFO"
+    logstash_1       | }
+    logstash_1       | {
+    logstash_1       |      "execution_time" => 9.0e-06,
+    logstash_1       |      "function_class" => nil,
+    logstash_1       |        "function_res" => "This is a return",
+    logstash_1       |          "@timestamp" => 2018-05-25T15:04:26.321Z,
+    logstash_1       |             "message" => "This is a message",
+    logstash_1       |                "type" => "logstash",
+    logstash_1       |          "stack_info" => nil,
+    logstash_1       |         "logger_name" => "Name",
+    logstash_1       |       "function_name" => "a",
+    logstash_1       |                "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
+    logstash_1       |                "port" => 33506,
+    logstash_1       |            "@version" => "1",
+    logstash_1       |                "tags" => [],
+    logstash_1       |               "class" => nil,
+    logstash_1       |                "host" => "MBP-C02WC1F4HV2Q.local",
+    logstash_1       |     "function_kwargs" => {},
+    logstash_1       |               "level" => "DEBUG"
+    logstash_1       | }
 
+4. Write a regular log
 
+    .. code-block:: bash
 
+    test_list = [1, 2, 3]
+    test_string = "This is a string"
+    logger.info('This is a message', extra = {"a_list": test_list, "a_string": test_string})
 
+Logstash output:
 
+    .. code-block:: bash
+
+    2018-05-25 17:08:15,654 - Name - INFO - This is a message
+
+    .. code-block:: bash
+
+    logstash_1       | {
+    logstash_1       |      "@timestamp" => 2018-05-25T15:08:15.654Z,
+    logstash_1       |         "message" => "This is a message",
+    logstash_1       |            "type" => "logstash",
+    logstash_1       |      "stack_info" => nil,
+    logstash_1       |     "logger_name" => "Name",
+    logstash_1       |            "path" => "test.py",
+    logstash_1       |            "port" => 33542,
+    logstash_1       |        "@version" => "1",
+    logstash_1       |          "a_list" => [
+    logstash_1       |         [0] 1,
+    logstash_1       |         [1] 2,
+    logstash_1       |         [2] 3
+    logstash_1       |     ],
+    logstash_1       |        "a_string" => "This is a string",
+    logstash_1       |            "tags" => [],
+    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
+    logstash_1       |           "level" => "INFO"
+    logstash_1       | }
 

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ How to use
     from magic_logger import MagicLogger
 
 2. Instantiate MagicLogger with a name. Logstash host is changed with `host` parameter.
-   If you have a specific and recurrent Logstash host, feel free to edit the `magic_logger.py` default host.
+   Define your own host in a constant file.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ How to use
     from magic_logger import MagicLogger
 
 2. Instantiate MagicLogger with a name. Logstash host is changed with kwarg `host`.
+   If you have a specific Logstash host, feel free to edit the `magic_logger.py` default host.
 
 .. code-block:: python
 
@@ -62,9 +63,43 @@ How to use
     def a():
         return 'This is a return'
 
-Output
+Terminal output:
 
 .. code-block:: bash
+
+    2018-05-25 11:39:21,663 - Name - INFO - Connection to logstash successful.
+    2018-05-25 11:39:21,669 - Name - DEBUG - This is a message
+
+Logstash output:
+
+.. code-block:: bash
+
+    logstash_1       | {
+    logstash_1       |      "@timestamp" => 2018-05-25T09:39:21.669Z,
+    logstash_1       |         "message" => "This is a message",
+    logstash_1       |            "type" => "logstash",
+    logstash_1       |      "stack_info" => nil,
+    logstash_1       |     "logger_name" => "Name",
+    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
+    logstash_1       |            "port" => 55684,
+    logstash_1       |        "@version" => "1",
+    logstash_1       |            "tags" => [],
+    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
+    logstash_1       |           "level" => "DEBUG"
+    logstash_1       | }
+    logstash_1       | {
+    logstash_1       |      "@timestamp" => 2018-05-25T09:39:21.663Z,
+    logstash_1       |         "message" => "Connection to logstash successful.",
+    logstash_1       |            "type" => "logstash",
+    logstash_1       |      "stack_info" => nil,
+    logstash_1       |     "logger_name" => "Name",
+    logstash_1       |            "path" => "/Users/nicolas.vo/kudoz/elk/MagicLogger/magic_logger/magic_logger.py",
+    logstash_1       |            "port" => 55684,
+    logstash_1       |        "@version" => "1",
+    logstash_1       |            "tags" => [],
+    logstash_1       |            "host" => "MBP-C02WC1F4HV2Q.local",
+    logstash_1       |           "level" => "INFO"
+    logstash_1       | }
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,28 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 
+Requirements
+------------
+
+Enable your Logstash pipeline to listen to incoming JSON streams on port 5000
+
+.. code-block:: json
+
+    input {
+        tcp {
+            port => 5000
+            codec => json
+        }
+    }
+    output {
+        elasticsearch {
+            hosts => ["elasticsearch:9200"]
+            index => "logstash_index"
+            document_type => "logtype"
+        }
+    stdout { codec => rubydebug }
+    }
+
 How to use
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-Logstash Logger
+MagicLogger
 ===============
 
 

--- a/magic_logger/magic_logger.py
+++ b/magic_logger/magic_logger.py
@@ -67,13 +67,19 @@ class MagicLogger(Logger):
                         **kwargs,
                         **{arg_name:arg_value for arg_name, arg_value in zip(inspect.getfullargspec(f).args, args)}
                 }
+
+                if isinstance(res, list): function_res = [str(res_elt) for res_elt in res]
+                elif isinstance(res, dict): function_res = {k:str(v) for k, v in res.items()}
+                else: function_res = str(res)
+
                 extra_decorate = {
                         'function_name': f.__name__,
                         'execution_time': execution_time,
                         'function_class': kwargs.get("self").__class__.__name__ if kwargs.get("self") else None,
-                        'function_kwargs': {k:str(v) if not isinstance(v, list) else [str(elt) for elt in v] for k, v in kwargs.items() if k not in self.blacklist},
-                        'function_res': res,
-                        'class': kwargs.get('self')
+                        'function_kwargs': {k:str(v) if not isinstance(v, list) else str(v) for k, v in kwargs.items() if k not in self.blacklist},
+			#'function_res': [str(res_elt) for res_elt in res] if isinstance(res, list) elif isinstance(res, dict) {k:str(v) for k, v in res.items()} else str(res),
+			'function_res': function_res,
+                       'class': kwargs.get('self')
                 }
 
                 self.log(level=level, msg=msg.format(**kwargs), extra_decorate=extra_decorate)
@@ -85,10 +91,8 @@ class MagicLogger(Logger):
     def log(self, level, msg, extra_decorate=None, *args, **kwargs):
         """
         Log 'msg % args' with the integer severity 'level'.
-
         To pass exception information, use the keyword argument exc_info with
         a true value, e.g.
-
         logger.log(level, "We have a %s", "mysterious problem", exc_info=1)
         """
 

--- a/magic_logger/magic_logger.py
+++ b/magic_logger/magic_logger.py
@@ -71,7 +71,7 @@ class MagicLogger(Logger):
                         'function_name': f.__name__,
                         'execution_time': execution_time,
                         'function_class': kwargs.get("self").__class__.__name__ if kwargs.get("self") else None,
-                        'function_kwargs': {k:str(v) for k, v in kwargs.items() if k not in self.blacklist},
+                        'function_kwargs': {k:str(v) if not isinstance(v, list) else [str(elt) for elt in v] for k, v in kwargs.items() if k not in self.blacklist},
                         'function_res': res,
                         'class': kwargs.get('self')
                 }

--- a/magic_logger/magic_logger.py
+++ b/magic_logger/magic_logger.py
@@ -77,9 +77,8 @@ class MagicLogger(Logger):
                         'execution_time': execution_time,
                         'function_class': kwargs.get("self").__class__.__name__ if kwargs.get("self") else None,
                         'function_kwargs': {k:str(v) if not isinstance(v, list) else str(v) for k, v in kwargs.items() if k not in self.blacklist},
-			#'function_res': [str(res_elt) for res_elt in res] if isinstance(res, list) elif isinstance(res, dict) {k:str(v) for k, v in res.items()} else str(res),
-			'function_res': function_res,
-                       'class': kwargs.get('self')
+                        'function_res': function_res,
+                        'class': kwargs.get('self')
                 }
 
                 self.log(level=level, msg=msg.format(**kwargs), extra_decorate=extra_decorate)


### PR DESCRIPTION
- convert function return to list of string elements, dict of string values, or simply cast return to string
- if a method has no return/no kwargs or args:
```
logstash_1       |      "function_class" => nil,
logstash_1       |        "function_res" => "None",
```
Is it better to filter and not log `function_class` and `function_res` at all?